### PR TITLE
Add/CommandBuilder and ShuffleboardBuilder

### DIFF
--- a/robotbase/src/main/java/com/systemmeltdown/robot/commands/CommandBuilder.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/commands/CommandBuilder.java
@@ -1,0 +1,112 @@
+package com.systemmeltdown.robot.commands;
+
+import com.systemmeltdown.robot.controls.GunnerControls;
+import com.systemmeltdown.robot.controls.InvertDriveControls;
+import com.systemmeltdown.robot.subsystems.ClimbSubsystem;
+import com.systemmeltdown.robot.subsystems.ControlPanelSub;
+import com.systemmeltdown.robot.subsystems.FeederSubsystem;
+import com.systemmeltdown.robot.subsystems.IntakeSub;
+import com.systemmeltdown.robot.subsystems.ShooterSubsystem;
+import com.systemmeltdown.robot.subsystems.StorageSubsystem;
+import com.systemmeltdown.robot.subsystems.TogglableLimelightSubsystem;
+import com.systemmeltdown.robot.subsystems.TurretSubsystem;
+import com.systemmeltdown.robotlib.subsystems.drive.FalconTrajectoryDriveSubsystem;
+
+public class CommandBuilder {
+    private FalconTrajectoryDriveSubsystem m_driveSub;
+    private TogglableLimelightSubsystem m_visionSub;
+    private InvertDriveControls m_driverControls;
+    private GunnerControls m_gunnerControls;
+    private ClimbSubsystem m_climbSub;
+    private ControlPanelSub m_controlPanelSub;
+    private FeederSubsystem m_feederSub;
+    private IntakeSub m_intakeSub;
+    private ShooterSubsystem m_shooterSub;
+    private StorageSubsystem m_storageSub;
+    private TurretSubsystem m_turretSub;
+
+    public CommandBuilder(InvertDriveControls driverControls, GunnerControls gunnerControls) {
+        m_driverControls = driverControls;
+        m_gunnerControls = gunnerControls;
+    }
+
+    public CommandBuilder withDriveSub(FalconTrajectoryDriveSubsystem driveSub) {
+        m_driveSub = driveSub;
+        return this;
+    }
+
+    public CommandBuilder withClimbSub(ClimbSubsystem climbSub) {
+        m_climbSub = climbSub;
+        return this;
+    }
+
+    public CommandBuilder withControlPanelSub(ControlPanelSub controlPanelSub) {
+        m_controlPanelSub = controlPanelSub;
+        return this;
+    }
+
+    public CommandBuilder withFeederSub(FeederSubsystem feederSub) {
+        m_feederSub = feederSub;
+        return this;
+    }
+
+    public CommandBuilder withIntakeSub(IntakeSub intakeSub) {
+        m_intakeSub = intakeSub;
+        return this;
+    }
+
+    public CommandBuilder withShooterSub(ShooterSubsystem shooterSubsystem) {
+        m_shooterSub = shooterSubsystem;
+        return this;
+    }
+
+    public CommandBuilder withStorageSub(StorageSubsystem storageSub) {
+        m_storageSub = storageSub;
+        return this;
+    }
+
+    public CommandBuilder withTurretSub(TurretSubsystem turretSub) {
+        m_turretSub = turretSub;
+        return this;
+    }
+
+    public CommandBuilder withVisionSub(TogglableLimelightSubsystem visonSub) {
+        m_visionSub = visonSub;
+        return this;
+    }
+
+    public void build() {
+        if (m_climbSub != null) {
+
+        }
+        if (m_controlPanelSub != null) {
+
+        }
+        if (m_driveSub != null) {
+
+            if (m_visionSub != null) {
+                m_driverControls.m_invertButton.whenPressed(new InvertDriveCommand(m_visionSub, m_driverControls));
+            }
+        }
+        if (m_feederSub != null) {
+
+        }
+        if (m_intakeSub != null) {
+            m_gunnerControls.m_leftTrigger
+                    .whileActiveContinuous(new IntakePickupBallCommand(m_intakeSub, m_gunnerControls));
+            m_gunnerControls.m_yButton.whenPressed(new IntakeToggleDirectionCommand(m_intakeSub));
+        }
+        if (m_shooterSub != null) {
+            m_gunnerControls.m_rightTrigger.whileActiveContinuous(new ShootCommand(m_shooterSub, m_gunnerControls));
+        }
+        if (m_storageSub != null) {
+
+        }
+        if (m_turretSub != null) {
+
+        }
+        if (m_visionSub != null) {
+            m_driverControls.m_changePipelineButton.whileHeld(new VisionChangePipelineCommand(m_visionSub));
+        }
+    }
+}

--- a/robotbase/src/main/java/com/systemmeltdown/robot/shuffleboard/ShuffleboardBuilder.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/shuffleboard/ShuffleboardBuilder.java
@@ -1,0 +1,109 @@
+package com.systemmeltdown.robot.shuffleboard;
+
+import java.util.ArrayList;
+
+import com.systemmeltdown.robot.subsystems.ClimbSubsystem;
+import com.systemmeltdown.robot.subsystems.ControlPanelSub;
+import com.systemmeltdown.robot.subsystems.FeederSubsystem;
+import com.systemmeltdown.robot.subsystems.IntakeSub;
+import com.systemmeltdown.robot.subsystems.ShooterSubsystem;
+import com.systemmeltdown.robot.subsystems.StorageSubsystem;
+import com.systemmeltdown.robot.subsystems.TogglableLimelightSubsystem;
+import com.systemmeltdown.robot.subsystems.TurretSubsystem;
+import com.systemmeltdown.robotlib.subsystems.ClosedLoopSubsystem;
+import com.systemmeltdown.robotlib.subsystems.drive.FalconTrajectoryDriveSubsystem;
+
+public class ShuffleboardBuilder {
+    private FalconTrajectoryDriveSubsystem m_driveSub;
+    private ClimbSubsystem m_climbSub;
+    private ControlPanelSub m_controlPanelSub;
+    private FeederSubsystem m_feederSub;
+    private IntakeSub m_intakeSub;
+    private ShooterSubsystem m_shooterSub;
+    private StorageSubsystem m_storageSub;
+    private TurretSubsystem m_turretSub;
+    private TogglableLimelightSubsystem m_visionSub;
+
+    public ShuffleboardBuilder withDriveSub(FalconTrajectoryDriveSubsystem driveSub) {
+        m_driveSub = driveSub;
+        return this;
+    }
+
+    public ShuffleboardBuilder withClimbSub(ClimbSubsystem climbSub) {
+        m_climbSub = climbSub;
+        return this;
+    }
+
+    public ShuffleboardBuilder withControlPanelSub(ControlPanelSub controlPanelSub) {
+        m_controlPanelSub = controlPanelSub;
+        return this;
+    }
+
+    public ShuffleboardBuilder withFeederSub(FeederSubsystem feederSub) {
+        m_feederSub = feederSub;
+        return this;
+    }
+
+    public ShuffleboardBuilder withIntakeSub(IntakeSub intakeSub) {
+        m_intakeSub = intakeSub;
+        return this;
+    }
+
+    public ShuffleboardBuilder withShooterSub(ShooterSubsystem shooterSubsystem) {
+        m_shooterSub = shooterSubsystem;
+        return this;
+    }
+
+    public ShuffleboardBuilder withStorageSub(StorageSubsystem storageSub) {
+        m_storageSub = storageSub;
+        return this;
+    }
+
+    public ShuffleboardBuilder withTurretSub(TurretSubsystem turretSub) {
+        m_turretSub = turretSub;
+        return this;
+    }
+
+    public ShuffleboardBuilder withVisionSub(TogglableLimelightSubsystem visonSub) {
+        m_visionSub = visonSub;
+        return this;
+    }
+
+    public void build() {
+        ArrayList<ClosedLoopSubsystem> subsystems = new ArrayList<>();
+        if (m_climbSub != null) {
+            subsystems.add(m_climbSub);
+        }
+        if (m_controlPanelSub != null) {
+            subsystems.add(m_controlPanelSub);
+        }
+        if (m_driveSub != null) {
+            subsystems.add(m_driveSub);
+        }
+        if (m_feederSub != null) {
+            subsystems.add(m_feederSub);
+        }
+        if (m_intakeSub != null) {
+            subsystems.add(m_intakeSub);
+        }
+        if (m_shooterSub != null) {
+            subsystems.add(m_shooterSub);
+        }
+        if (m_storageSub != null) {
+            subsystems.add(m_storageSub);
+            new CellNumberWidget("Robot", m_storageSub);
+        }
+        if (m_turretSub != null) {
+            subsystems.add(m_turretSub);
+        }
+        if (m_visionSub != null) {
+            subsystems.add(m_visionSub);
+        }
+        if (!subsystems.isEmpty()) {
+            new FailsafeButtonWidget("tabTitle", subsystems);
+        }
+        for (int i = 0; i < 4; i++) {
+            new AutoWaitTimeAndChooser("AUTO", i);
+        }
+    }
+}

--- a/robotbase/src/main/java/frc/robot/RobotContainer.java
+++ b/robotbase/src/main/java/frc/robot/RobotContainer.java
@@ -7,34 +7,24 @@
 
 package frc.robot;
 
-//import com.systemmeltdown.robot.commands.ShootCommand;
+import com.systemmeltdown.robot.commands.ShootCommand;
 import com.systemmeltdown.robot.subsystems.IntakeSub;
-//import com.systemmeltdown.robot.subsystems.ShooterSubsystem;
-//import com.systemmeltdown.robot.subsystems.StorageSubsystem;
+import com.systemmeltdown.robot.subsystems.ShooterSubsystem;
+import com.systemmeltdown.robot.subsystems.StorageSubsystem;
 import com.systemmeltdown.robotlib.subsystems.drive.FalconTrajectoryDriveSubsystem;
 import com.systemmeltdown.robot.commands.AutoTemporaryCommand;
-import com.systemmeltdown.robot.commands.IntakePickupBallCommand;
-import com.systemmeltdown.robot.commands.IntakeToggleDirectionCommand;
-import com.systemmeltdown.robot.commands.InvertDriveCommand;
-import com.systemmeltdown.robot.commands.VisionChangePipelineCommand;
+import com.systemmeltdown.robot.commands.CommandBuilder;
 import com.systemmeltdown.robot.controls.GunnerControls;
 import com.systemmeltdown.robot.controls.InvertDriveControls;
 import com.systemmeltdown.robot.subsystems.ClimbSubsystem;
 import com.systemmeltdown.robot.subsystems.SubsystemFactory;
 import com.systemmeltdown.robot.subsystems.TogglableLimelightSubsystem;
-import com.systemmeltdown.robot.subsystems.TogglableLimelightSubsystem.PipelineIndex;
 import com.systemmeltdown.robotlib.commands.DriveProportionalCommand;
-import com.systemmeltdown.robotlib.subsystems.ClosedLoopSubsystem;
 import com.systemmeltdown.robotlib.subsystems.drive.FalconTrajectoryDriveSubsystem;
-import com.systemmeltdown.robot.shuffleboard.CellNumberWidget;
-import com.systemmeltdown.robot.shuffleboard.AutoWaitTimeAndChooser;
-import com.systemmeltdown.robot.shuffleboard.FailsafeButtonWidget;
-import com.systemmeltdown.robot.shuffleboard.LoggerTab;
+import com.systemmeltdown.robot.shuffleboard.ShuffleboardBuilder;
 
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj2.command.Command;
-
-import java.util.ArrayList;
 
 /**
  * This class is where the bulk of the robot should be declared. Since
@@ -53,8 +43,6 @@ public class RobotContainer {
 
   private final InvertDriveControls m_driverControls = new InvertDriveControls(new XboxController(0), .1);
   private final GunnerControls m_gunnerControls = new GunnerControls(new XboxController(1));
-
-  private final AutoWaitTimeAndChooser[] m_waitTimeAndChooser = new AutoWaitTimeAndChooser[3];
 
   /**
    * The container for the robot. Contains subsystems, OI devices, and commands.
@@ -80,28 +68,31 @@ public class RobotContainer {
    * passing it to a {@link edu.wpi.first.wpilibj2.command.button.JoystickButton}.
    */
   private void configureButtonBindings() {
-    // m_gunnerControls.m_shootButton.whenPressed(command)
-    m_driverControls.m_invertButton.whenPressed(new InvertDriveCommand(m_visionSub, m_driverControls));
-    m_driverControls.m_changePipelineButton.whileHeld(new VisionChangePipelineCommand(m_visionSub));
-    // m_gunnerControls.m_rightTrigger.whileActiveContinuous(new ShootCommand(m_shootSub, m_gunnerControls));
-    m_gunnerControls.m_leftTrigger.whileActiveContinuous(new IntakePickupBallCommand(m_intakeSub, m_gunnerControls));
-    m_gunnerControls.m_yButton.whenPressed(new IntakeToggleDirectionCommand(m_intakeSub));
+    new CommandBuilder(m_driverControls, m_gunnerControls)
+      // .withClimbSub(m_climbSub)
+      // .withControlPanelSub(m_controlPanelSub)
+      .withDriveSub(m_driveSub)
+      // .withFeederSub(m_feederSub)
+      .withIntakeSub(m_intakeSub)
+      // .withShooterSub(m_shooterSubsystem)
+      // .withStorageSub(m_storageSub)
+      // .withTurretSub(m_turretSub)
+      .withVisionSub(m_visionSub)
+      .build();
   }
 
   private void configureShuffleboard() {
-    //CellNumberWidget cellNumberWidget = new CellNumberWidget("Robot", m_storageSub);
-    
-    // for(int i = 0; i < 4; i++) {
-    //  m_waitTimeAndChooser[i] = new AutoWaitTimeAndChooser("AUTO", i);
-    // }
-
-    LoggerTab loggerTab = new LoggerTab();
-    ArrayList<ClosedLoopSubsystem> subsystems = new ArrayList<>();
-    // subsystems.add(m_shootSub);
-    // subsystems.add(m_intakeSub);
-    // subsystems.add(m_storageSub);
-    subsystems.add(m_driveSub);
-    FailsafeButtonWidget failsafeButton = new FailsafeButtonWidget("Robot", subsystems);
+    new ShuffleboardBuilder()
+    // .withClimbSub(m_climbSub)
+    // .withControlPanelSub(m_controlPanelSub)
+    .withDriveSub(m_driveSub)
+    // .withFeederSub(m_feederSub)
+    .withIntakeSub(m_intakeSub)
+    // .withShooterSub(m_shooterSubsystem)
+    // .withStorageSub(m_storageSub)
+    // .withTurretSub(m_turretSub)
+    .withVisionSub(m_visionSub)
+    .build();
   }
 
   private void configureDriveSub() {


### PR DESCRIPTION
The focus of these two classes is to provide a clean way to comment out subsystems and remove their dependent commands and shuffleboard objects respectively. They both have with<subsystem> methods, which place the subsystem in the Builder, and a build command, which creates commands and shuffleboard objects based on which subsystems were passed in.