### PR TITLE
Move turret PID controller to the turret subsystem

### DIFF
--- a/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/SubsystemFactory.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/SubsystemFactory.java
@@ -7,6 +7,8 @@ import com.systemmeltdown.robotlib.subsystems.drive.SingleSpeedTalonDriveSubsyst
 import com.systemmeltdown.robot.subsystems.TogglableLimelightSubsystem.PipelineIndex;
 import com.systemmeltdown.robotlib.subsystems.LimelightSubsystem;
 import edu.wpi.first.wpilibj.DigitalInput;
+import edu.wpi.first.wpilibj.Servo;
+
 import com.systemmeltdown.robotlib.subsystems.drive.FalconTrajectoryDriveSubsystem;
 import com.systemmeltdown.robotlib.subsystems.drive.SingleSpeedFalconDriveSubsystem;
 
@@ -112,11 +114,15 @@ public class SubsystemFactory {
     }
 
     public TurretSubsystem CreateTurretSubsystem() {
-        // Need device IDs
-        throw new UnsupportedOperationException();
-        /*
-         * TurretSubsystem subsystem = new TurretSubsystem(-1); return subsystem;
-         */
+        WPI_TalonSRX rotateMotor = new WPI_TalonSRX(Constants.TURRET_ROTATE_MOTOR);
+        Servo hoodMotor = new Servo(Constants.TURRET_HOOD_MOTOR);
+        TurretSubsystem subsystem = new TurretSubsystem(rotateMotor, hoodMotor);
+        TurretSubsystem.Configuration config = new TurretSubsystem.Configuration();
+        config.m_turretAimP = Constants.TURRET_AIM_P;
+        config.m_turretAimI = Constants.TURRET_AIM_I;
+        config.m_turretAimD = Constants.TURRET_AIM_D;
+        subsystem.setConfiguration(config);
+        return subsystem;
     }
 
     public TogglableLimelightSubsystem CreateLimelightSubsystem() {

--- a/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/TurretSubsystem.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/TurretSubsystem.java
@@ -3,20 +3,52 @@ package com.systemmeltdown.robot.subsystems;
 import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 import com.systemmeltdown.robotlib.subsystems.ClosedLoopSubsystem;
+import com.systemmeltdown.robotlib.util.Utility;
+
+import edu.wpi.first.wpilibj.Servo;
+import edu.wpi.first.wpilibj.controller.PIDController;
 
 public class TurretSubsystem extends ClosedLoopSubsystem {
     private WPI_TalonSRX m_rotateMotor;
+    private PIDController m_horzAimController;
+    private double m_horzAimMeasurement;
+    private boolean m_horzAimControllerActive;
 
-    public TurretSubsystem(int rotateMotorID) {
-        m_rotateMotor = new WPI_TalonSRX(rotateMotorID);
+    // TODO replace with the specific class for the motor
+    private Servo m_hoodServo;
+
+    private Configuration m_configuration;
+
+    static public class Configuration
+    {
+        public double m_turretAimP = 1e-3;
+        public double m_turretAimI = 0;
+        public double m_turretAimD = 0;      
+    }
+
+    public TurretSubsystem(WPI_TalonSRX rotateMotor, Servo hoodServo) {
+        m_configuration = new Configuration();
+        m_rotateMotor = rotateMotor;
+        m_hoodServo = hoodServo;
+        m_horzAimController = new PIDController(0, 0, 0);
+        m_horzAimControllerActive = false;
+        m_horzAimMeasurement = 0;
+
+        configurePidControllers();
 
         // add dashboard controls for children
         addChild("rotateMotor", m_rotateMotor);
+        addChild("hoodServo", m_hoodServo);
+        addChild("horzAimPID", m_horzAimController);
     }
 
     @Override
     public void periodic() {
-        // This method will be called once per scheduler run
+        if(m_horzAimControllerActive && isClosedLoopEnabled()) {
+            double cv = m_horzAimController.calculate(m_horzAimMeasurement);
+            double turretRotateSpeed = Utility.clamp(cv, -1, 1);
+            setTurretMotor(turretRotateSpeed);
+        }
     }
 
     /**
@@ -30,7 +62,37 @@ public class TurretSubsystem extends ClosedLoopSubsystem {
         m_rotateMotor.set(ControlMode.PercentOutput, percentOutput);
     }
 
-    public int getSensorPosition() {
-        return m_rotateMotor.getSelectedSensorPosition();
+    public void setHoodAngle(double degrees) {
+        m_hoodServo.setAngle(degrees);
+    }
+
+    /**
+     * Set values for the horizontal aim closed loop controller. This needs to be
+     * called every time step for the loop to be effective.
+     * @param setpoint target value for the horizontal aim
+     * @param measurement current value of the horizontal aim
+     */
+    public void setHorizontalAimClosedLoop(double setpoint, double measurement) {
+        m_horzAimControllerActive = true;
+        m_horzAimMeasurement = measurement;
+        m_horzAimController.setSetpoint(setpoint);
+    }
+
+    /**
+     * Disable closed loop control for the horizontal aiming
+     */
+    public void disableHorizontalAimClosedLoop() {
+        m_horzAimControllerActive = false;
+    }
+
+    public void setConfiguration(Configuration configuration) {
+        m_configuration = configuration;
+        configurePidControllers();
+    }
+
+    private void configurePidControllers() {
+        m_horzAimController.setP(m_configuration.m_turretAimP);
+        m_horzAimController.setI(m_configuration.m_turretAimI);
+        m_horzAimController.setD(m_configuration.m_turretAimD);
     }
 }

--- a/robotbase/src/main/java/frc/robot/Constants.java
+++ b/robotbase/src/main/java/frc/robot/Constants.java
@@ -63,6 +63,8 @@ public final class Constants {
   public static final int SCISSOR_SOLENOID = -1;
   public static final int WINCH_MOTOR_LEFT = -1;
   public static final int WINCH_MOTOR_RIGHT = -1;
+  public static final int TURRET_ROTATE_MOTOR = -1;
+  public static final int TURRET_HOOD_MOTOR = -1;
 
   /** Intake motor */
   public static final int INTAKE_MOTOR_ID = 23;


### PR DESCRIPTION
This moves the PID controller used for horizontally aiming the turret into the turret subsystem. This also adds support for rotating the hood on the turret.