### PR TITLE
Add closed loop control to shooter subsystem

### DIFF
--- a/robotbase/src/main/java/com/systemmeltdown/robot/commands/ShootCommand.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/commands/ShootCommand.java
@@ -5,10 +5,13 @@ import com.systemmeltdown.robot.subsystems.ShooterSubsystem;
 
 import edu.wpi.first.wpilibj.GenericHID.Hand;
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants;
 
 /**
  * Tells the turret to shoot by calling runMotor() on the {@link ShooterSubsystem}.
- * 
+ *
+ * This command uses a constant shooting velocity and needs to be
+ * paired with an aiming hood.
  * @category Turret
  */
 public class ShootCommand extends CommandBase {
@@ -28,11 +31,11 @@ public class ShootCommand extends CommandBase {
 
     @Override
     public void execute() {
-        m_shootSub.runMotor(m_gunnerControls.getTriggerValue(Hand.kRight));
+        m_shootSub.setMotorSpeed(Constants.SHOOTER_MAX_SPEED_RPM);
     }
 
     @Override
     public void end(boolean interupted) {
-        m_shootSub.runMotor(0.0);
+        m_shootSub.runMotorOpenLoop(0.0);
     }
 }

--- a/robotbase/src/main/java/com/systemmeltdown/robot/commands/ShootLowGoal.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/commands/ShootLowGoal.java
@@ -4,6 +4,7 @@ import com.systemmeltdown.robot.controls.GunnerControls;
 
 import edu.wpi.first.wpilibj.GenericHID.Hand;
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants;
 
 /**
  * Auto command that shoots power cells into the low goal. Will continue to shoot until the button that
@@ -31,11 +32,11 @@ public class ShootLowGoal extends CommandBase {
         //Add the code to move the hood to the low goal shooting position.
         //There is no reflective tape on the low goal for the camera to see so we will need
         //to set the hood.
-        m_shooterSubsystem.runMotor(m_gunnerControls.getTriggerValue(Hand.kRight));
+        m_shooterSubsystem.setMotorSpeed(Constants.SHOOTER_LOW_GOAL_SPEED_RPM);
     }
 
     @Override
     public void end(boolean interrupted) {
-        m_shooterSubsystem.runMotor(0.0);
+        m_shooterSubsystem.runMotorOpenLoop(0);
     }
 }

--- a/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/ShooterSubsystem.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/ShooterSubsystem.java
@@ -1,7 +1,12 @@
 package com.systemmeltdown.robot.subsystems;
 
+import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.TalonFXFeedbackDevice;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonFX;
 import com.systemmeltdown.robotlib.subsystems.ClosedLoopSubsystem;
+
+import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
+import frc.robot.Constants;
 
 /**
  * The subsystem for the turret.
@@ -20,7 +25,42 @@ public class ShooterSubsystem extends ClosedLoopSubsystem {
   public ShooterSubsystem(int shooterMotorID1, int shooterMotorID2) {
     m_shooterMotor1 = new WPI_TalonFX(shooterMotorID1);
     m_shooterMotor2 = new WPI_TalonFX(shooterMotorID2);
+
+    addChild("motor1", m_shooterMotor1);
+    addChild("motor2", m_shooterMotor2);
+
+    // reset motor configs to known state
+    m_shooterMotor1.configFactoryDefault(Constants.TIMEOUT_MS);
+    m_shooterMotor2.configFactoryDefault(Constants.TIMEOUT_MS);
+
     m_shooterMotor2.setInverted(true);
+    m_shooterMotor2.follow(m_shooterMotor1);
+
+    m_shooterMotor1.configSelectedFeedbackSensor(TalonFXFeedbackDevice.IntegratedSensor,
+                                                 0,
+                                                 Constants.TIMEOUT_MS);
+
+    // >>> Change this if positive motor output gives negative encoder feedback <<<
+    m_shooterMotor1.setSensorPhase(true);
+
+    // Configure output range
+    m_shooterMotor1.configNominalOutputForward(0, Constants.TIMEOUT_MS);
+    m_shooterMotor1.configNominalOutputReverse(0, Constants.TIMEOUT_MS);
+    m_shooterMotor1.configPeakOutputForward(Constants.SHOOTER_MOTOR_PEAK_OUTPUT, Constants.TIMEOUT_MS);
+    m_shooterMotor1.configPeakOutputReverse(0, Constants.TIMEOUT_MS); // don't run the motors in reverse
+
+    m_shooterMotor1.config_kP(0, Constants.SHOOTER_P, Constants.TIMEOUT_MS);
+    m_shooterMotor1.config_kI(0, Constants.SHOOTER_I, Constants.TIMEOUT_MS);
+    m_shooterMotor1.config_kD(0, Constants.SHOOTER_D, Constants.TIMEOUT_MS);
+    m_shooterMotor1.config_kF(0, Constants.SHOOTER_F, Constants.TIMEOUT_MS);
+  }
+
+  @Override
+  public void initSendable(SendableBuilder builder) {
+    super.initSendable(builder);
+
+    // this might be included in the motor child control
+    builder.addDoubleProperty("motorSpeed", this::getMotorSpeed, this::setMotorSpeed);
   }
 
   @Override
@@ -29,12 +69,29 @@ public class ShooterSubsystem extends ClosedLoopSubsystem {
   }
 
   /**
-   * Sets the motors to the speed that is passed into it.
-   * 
-   * @param speed The speed to set the motors to.
+   * Set the motor to a percent output. This bypasses closed-loop control.
+   * @param output
    */
-  public void runMotor(double speed) {
-    m_shooterMotor1.set(speed);
-    m_shooterMotor2.set(speed);
+  public void runMotorOpenLoop(double output)
+  {
+    m_shooterMotor1.set(ControlMode.PercentOutput, output);
+  }
+
+  /**
+   * Set the motor speed using closed-loop control
+   * @param rpm rotations per minute
+   */
+  public void setMotorSpeed(double rpm)
+  {
+    double nativeSpeed = rpm * Constants.FALCON_ENCODER_CPR / Constants.MINUTES_TO_100_MS;
+    m_shooterMotor1.set(ControlMode.Velocity, nativeSpeed);
+  }
+
+  /**
+   * @return current motor velocity in rpm
+   */
+  public double getMotorSpeed()
+  {
+    return m_shooterMotor1.getSelectedSensorPosition(0) * Constants.MINUTES_TO_100_MS / Constants.FALCON_ENCODER_CPR;
   }
 }

--- a/robotbase/src/main/java/frc/robot/Constants.java
+++ b/robotbase/src/main/java/frc/robot/Constants.java
@@ -24,6 +24,21 @@ public final class Constants {
   public static final double UPDATE_PERIOD = Robot.kDefaultPeriod;
 
   /**
+   * When setting values on components, wait this long for a response before
+   * failing. milliseconds
+   */
+  public static final int TIMEOUT_MS = 30;
+
+  /**
+   * The PID code built into the Talon controllers uses 1023 to represent
+   * full motor output
+   */
+  public static final int TALON_PID_FULL = 1023;
+
+  /** 1min/100ms */
+  public static final int MINUTES_TO_100_MS = 600;
+
+  /**
    * CAN IDS 1-10 Core Components of the Robot
    */
   public static final int PDP = 1;
@@ -56,6 +71,9 @@ public final class Constants {
 
   public static final double WHEEL_DIAMETER_IN_METERS = 0.1524;
   public static final int ENCODER_CPR = 1024;
+
+  /** Clicks per rotation for the internal encoder in the Falcon 500 */
+  public static final int FALCON_ENCODER_CPR = 2048;
 
   public static final double ENCODER_DISTANCE_PER_PULSE = 
     (WHEEL_DIAMETER_IN_METERS * Math.PI) / (double) ENCODER_CPR;
@@ -177,6 +195,30 @@ public final class Constants {
   public static final int TOF_LOW_RANGE = 130;
   public static final int TOF_HIGH_RANGE = 225;
   
+  /**
+   * Current limit for shooter motor. Set this to limit the
+   * wheels to a safe speed (<= 4kRPM)
+   */
+  public static final double SHOOTER_MOTOR_PEAK_OUTPUT = 0.6;
+
+  /**
+   * Run the motor at peak output and measure the encoder velocity in
+   * ticks per 100ms (this is reported by getSelectedSensorVelocity)
+   */
+  public static final int SHOOTER_ENCODER_VELOCITY_AT_PEAK_OUTPUT = 1;
+
+  /** Maximum safe speed for the shooter wheels */
+  public static final int SHOOTER_MAX_SPEED_RPM = 4000;
+
+  /** Speed for shooting in the low goal SET THIS */
+  public static final int SHOOTER_LOW_GOAL_SPEED_RPM = 1000;
+
+  /** Shooter PIDF values */
+  public static final double SHOOTER_P = 0;
+  public static final double SHOOTER_I = 0;
+  public static final double SHOOTER_D = 0;
+  public static final double SHOOTER_F = SHOOTER_MOTOR_PEAK_OUTPUT * TALON_PID_FULL / SHOOTER_ENCODER_VELOCITY_AT_PEAK_OUTPUT;
+
   /**
    * Current spike threshold for detecting that we have clamped the bar
    * at the start of climb. A/s


### PR DESCRIPTION
This configures the shooter motors for closed loop control. The PIDF values still need to be tuned.