### PR TITLE
Add/support output range to vl53 lox

### DIFF
--- a/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/IntakeSubsystem.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/IntakeSubsystem.java
@@ -33,6 +33,8 @@ public class IntakeSubsystem extends ClosedLoopSubsystem {
         m_arduinoUSB = new ArduinoUSBController(Constants.ARDUINO_DEVICE_NAME);
 
         m_arduinoUSB.start();
+
+        resetArduino();
     }
 
     /**
@@ -72,6 +74,11 @@ public class IntakeSubsystem extends ClosedLoopSubsystem {
     }
 
     /**
+     * Below is everything that handles the Arduino connected to the TOFs.
+     * Also, in order to work properly after a redeploy, the TOF's need to sense an update.
+     */
+
+    /**
 	 * Get the count number of powercells in the intake.
 	 */
 	public int getCount() {
@@ -92,8 +99,24 @@ public class IntakeSubsystem extends ClosedLoopSubsystem {
 		if (!m_arduinoUSB.isConnected()) {
 			return;
         }
-        
+        String[] fieldNames = { "lowRange", "highRange" };
+        int[] ranges = {lowRange, highRange};
+        m_arduinoUSB.setDeviceField("intakeCounter", fieldNames, ranges);
+    }
+
+    public void setTOFRangeLow(int lowRange) {
+        // Check if the arduino is connected before getting values.
+		if (!m_arduinoUSB.isConnected()) {
+			return;
+        }
         m_arduinoUSB.setDeviceField("intakeCounter", "lowRange", lowRange);
+    }
+
+    public void setTOFRangeHigh(int highRange) {
+        // Check if the arduino is connected before getting values.
+		if (!m_arduinoUSB.isConnected()) {
+			return;
+        }
         m_arduinoUSB.setDeviceField("intakeCounter", "highRange", highRange);
     }
 

--- a/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/IntakeSubsystem.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/IntakeSubsystem.java
@@ -33,8 +33,6 @@ public class IntakeSubsystem extends ClosedLoopSubsystem {
         m_arduinoUSB = new ArduinoUSBController(Constants.ARDUINO_DEVICE_NAME);
 
         m_arduinoUSB.start();
-        
-        setTOFRange(Constants.TOF_LOW_RANGE, Constants.TOF_HIGH_RANGE);
     }
 
     /**
@@ -93,5 +91,13 @@ public class IntakeSubsystem extends ClosedLoopSubsystem {
         
         m_arduinoUSB.setDeviceField("intakeCounter", "lowRange", lowRange);
         m_arduinoUSB.setDeviceField("intakeCounter", "highRange", highRange);
+    }
+
+    /**
+     * Resets arduino by sending a boolean to tell it to rerun it's setup method.
+     * Required to be called after redeploy.
+     */
+    public void resetArduino() {
+        m_arduinoUSB.setDeviceField("intakeCounter", "needsReset", true);
     }
 }

--- a/robotbase/src/main/java/frc/robot/Constants.java
+++ b/robotbase/src/main/java/frc/robot/Constants.java
@@ -174,8 +174,10 @@ public final class Constants {
    */
 
   public static final String ARDUINO_DEVICE_NAME = "ttyACM0";
-  public static final int TOF_LOW_RANGE = 130;
-  public static final int TOF_HIGH_RANGE = 225;
+
+  //Default mid-range values for intake TOFs.
+  public static final int TOF_LOW_RANGE = 0;
+  public static final int TOF_HIGH_RANGE = 0;
   
   /**
    * Current spike threshold for detecting that we have clamped the bar

--- a/robotbase/src/main/java/frc/robot/Robot.java
+++ b/robotbase/src/main/java/frc/robot/Robot.java
@@ -108,6 +108,7 @@ public class Robot extends TimedRobot {
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }
+    RobotContainer.m_intakeSub.setTOFRange(Constants.TOF_LOW_RANGE, Constants.TOF_HIGH_RANGE);
   }
 
   /**

--- a/robotbase/src/main/java/frc/robot/Robot.java
+++ b/robotbase/src/main/java/frc/robot/Robot.java
@@ -10,8 +10,6 @@ package frc.robot;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
-import org.json.simple.parser.ParseException;
-
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj2.command.Command;

--- a/robotbase/src/main/java/frc/robot/Robot.java
+++ b/robotbase/src/main/java/frc/robot/Robot.java
@@ -63,7 +63,6 @@ public class Robot extends TimedRobot {
     // block in order for anything in the Command-based framework to work.
     CommandScheduler.getInstance().run();
     Shuffleboard.update();
-    //System.out.println(m_robotContainer.m_intakeSub.getCount());
   }
 
   /**
@@ -78,12 +77,12 @@ public class Robot extends TimedRobot {
   }
 
   /**
-   * This autonomous runs the autonomous command selected by your {@link RobotContainer} class.
+   * This autonomous runs the autonomous command selected by your
+   * {@link RobotContainer} class.
    */
   @Override
   public void autonomousInit() {
-    //m_autonomousCommand = m_robotContainer.getAutonomousCommand();
-
+    // m_autonomousCommand = m_robotContainer.getAutonomousCommand();
 
     // schedule the autonomous command (example)
     if (m_autonomousCommand != null) {
@@ -108,7 +107,6 @@ public class Robot extends TimedRobot {
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }
-    RobotContainer.m_intakeSub.setTOFRange(Constants.TOF_LOW_RANGE, Constants.TOF_HIGH_RANGE);
   }
 
   /**

--- a/robotbase/src/main/java/frc/robot/RobotContainer.java
+++ b/robotbase/src/main/java/frc/robot/RobotContainer.java
@@ -51,7 +51,7 @@ public class RobotContainer {
   // The robot's subsystems and commands are defined here...
   //private FalconTrajectoryDriveSubsystem m_driveSub;
   // private final ShooterSubsystem m_shootSub;
-  public final IntakeSubsystem m_intakeSub;
+  public static IntakeSubsystem m_intakeSub;
   // private final StorageSubsystem m_storageSub;
   private final TogglableLimelightSubsystem m_visionSub;
   private final ClimbSubsystem m_climbSub;
@@ -75,11 +75,12 @@ public class RobotContainer {
     m_visionSub = subsystemFactory.CreateLimelightSubsystem();
     m_climbSub = null; // subsystemFactory.CreateClimbSubsystem();
 
-
     // Configure the button bindings
     configureDriveSub();
     configureButtonBindings();
     configureShuffleboard();
+
+    m_intakeSub.resetArduino();
   }
 
   /**

--- a/robotbase/src/main/java/frc/robot/RobotContainer.java
+++ b/robotbase/src/main/java/frc/robot/RobotContainer.java
@@ -39,12 +39,12 @@ import java.util.ArrayList;
  */
 public class RobotContainer {
   // The robot's subsystems and commands are defined here...
-  //private FalconTrajectoryDriveSubsystem m_driveSub;
-  // private final ShooterSubsystem m_shootSub;
+  private FalconTrajectoryDriveSubsystem m_driveSub;
+  private final ShooterSubsystem m_shootSub;
   public static IntakeSubsystem m_intakeSub;
   // private final StorageSubsystem m_storageSub;
   private final TogglableLimelightSubsystem m_visionSub;
-  private final ClimbSubsystem m_climbSub;
+  //private final ClimbSubsystem m_climbSub;
 
 
   private final InvertDriveControls m_driverControls;
@@ -58,12 +58,12 @@ public class RobotContainer {
    */
   public RobotContainer() {
     SubsystemFactory subsystemFactory = new SubsystemFactory();
-    m_driveSub = subsystemFactory.CreateFalconTrajectoryDriveSubsystem();
-    //m_shootSub = subsystemFactory.CreateShooterSubsystem();
+    //m_driveSub = subsystemFactory.CreateFalconTrajectoryDriveSubsystem();
+    m_shootSub = subsystemFactory.CreateShooterSubsystem();
     m_intakeSub = subsystemFactory.CreateIntakeSubsystem();
     // m_storageSub = subsystemFactory.CreateStorageSubsystem();
     m_visionSub = subsystemFactory.CreateLimelightSubsystem();
-    m_climbSub = null; // subsystemFactory.CreateClimbSubsystem();
+    //m_climbSub = null; // subsystemFactory.CreateClimbSubsystem();
 
     // Configure the button bindings
     m_driverControls = new InvertDriveControls.InvertDriveControlsBuilder(new XboxController(0), .1)
@@ -78,8 +78,6 @@ public class RobotContainer {
 
     configureDriveSub();
     configureShuffleboard();
-
-    m_intakeSub.resetArduino();
   }
 
   private void configureShuffleboard() {

--- a/robotbase/src/main/java/frc/robot/RobotContainer.java
+++ b/robotbase/src/main/java/frc/robot/RobotContainer.java
@@ -30,8 +30,6 @@ import com.systemmeltdown.robotlib.subsystems.ClosedLoopSubsystem;
 import com.systemmeltdown.robot.shuffleboard.AutoWaitTimeAndChooser;
 import com.systemmeltdown.robot.shuffleboard.FailsafeButtonWidget;
 import com.systemmeltdown.robot.shuffleboard.LoggerTab;
-import com.systemmeltdown.robotlib.sensors.VL53LOXSensorOutput;
-import com.systemmeltdown.robotlib.subsystems.VL53LOXSensorOutputSubsystem;
 
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.SerialPort.Port;


### PR DESCRIPTION
The range values of the intake's arduino can now be set from within frc2020. Dependent on branch [add/support-for-range-input-VL53LOX](https://github.com/frc2357/robotlib2357/pull/69) in robotlib.