### PR TITLE
Add/command to spin shooter motor at 2000 rpm at start up

### DIFF
--- a/robotbase/src/main/java/com/systemmeltdown/robot/commands/ShootCommand.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/commands/ShootCommand.java
@@ -30,12 +30,12 @@ public class ShootCommand extends CommandLoggerBase {
     @Override
     public void initialize() {
         super.initialize();
-        m_shootSub.setMotorSpeed(Constants.MAX_FALCON_SPEED);
+        m_shootSub.setMotorSpeed(Constants.SHOOTER_MAX_SPEED_RPM);
     }
 
     @Override
     public void end(boolean interrupted) {
         super.end(interrupted);
-        m_shootSub.setMotorSpeed(Constants.SHOOTER_MAX_SPEED_RPM);
+        m_shootSub.setMotorSpeed(Constants.SHOOTER_MAX_RESTING_SPEED);
     }
 }

--- a/robotbase/src/main/java/com/systemmeltdown/robot/commands/ShootCommand.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/commands/ShootCommand.java
@@ -29,7 +29,6 @@ public class ShootCommand extends CommandLoggerBase {
 
     @Override
     public void initialize() {
-        super.initialize();
         m_shootSub.setMotorSpeed(Constants.SHOOTER_MAX_SPEED_RPM);
     }
 

--- a/robotbase/src/main/java/com/systemmeltdown/robot/commands/ShootCommand.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/commands/ShootCommand.java
@@ -28,13 +28,14 @@ public class ShootCommand extends CommandLoggerBase {
     }
 
     @Override
-    public void execute() {
-        m_shootSub.setMotorSpeed(Constants.SHOOTER_MAX_SPEED_RPM);
+    public void initialize() {
+        super.initialize();
+        m_shootSub.setMotorSpeed(Constants.MAX_FALCON_SPEED);
     }
 
     @Override
     public void end(boolean interrupted) {
         super.end(interrupted);
-        m_shootSub.runMotorOpenLoop(0.0);
+        m_shootSub.setMotorSpeed(Constants.SHOOTER_MAX_SPEED_RPM);
     }
 }

--- a/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/ShooterSubsystem.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/ShooterSubsystem.java
@@ -53,6 +53,8 @@ public class ShooterSubsystem extends ClosedLoopSubsystem {
     m_shooterMotor1.config_kI(0, Constants.SHOOTER_I, Constants.TIMEOUT_MS);
     m_shooterMotor1.config_kD(0, Constants.SHOOTER_D, Constants.TIMEOUT_MS);
     m_shooterMotor1.config_kF(0, Constants.SHOOTER_F, Constants.TIMEOUT_MS);
+
+    setMotorSpeed(4000);
   }
 
   @Override

--- a/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/ShooterSubsystem.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/ShooterSubsystem.java
@@ -54,7 +54,7 @@ public class ShooterSubsystem extends ClosedLoopSubsystem {
     m_shooterMotor1.config_kD(0, Constants.SHOOTER_D, Constants.TIMEOUT_MS);
     m_shooterMotor1.config_kF(0, Constants.SHOOTER_F, Constants.TIMEOUT_MS);
 
-    setMotorSpeed(4000);
+    setMotorSpeed(Constants.SHOOTER_MAX_SPEED_RPM);
   }
 
   @Override

--- a/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/ShooterSubsystem.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/ShooterSubsystem.java
@@ -54,7 +54,7 @@ public class ShooterSubsystem extends ClosedLoopSubsystem {
     m_shooterMotor1.config_kD(0, Constants.SHOOTER_D, Constants.TIMEOUT_MS);
     m_shooterMotor1.config_kF(0, Constants.SHOOTER_F, Constants.TIMEOUT_MS);
 
-    setMotorSpeed(Constants.SHOOTER_MAX_SPEED_RPM);
+    setMotorSpeed(Constants.SHOOTER_MAX_RESTING_SPEED);
   }
 
   @Override

--- a/robotbase/src/main/java/frc/robot/Constants.java
+++ b/robotbase/src/main/java/frc/robot/Constants.java
@@ -226,6 +226,9 @@ public final class Constants {
   /** Maximum safe speed for the shooter wheels */
   public static final int SHOOTER_MAX_SPEED_RPM = 4000;
 
+  /** Maximum speed for the falcons running the shooter motors */
+  public static final int MAX_FALCON_SPEED = 6000;
+
   /** Speed for shooting in the low goal SET THIS */
   public static final int SHOOTER_LOW_GOAL_SPEED_RPM = 1000;
 

--- a/robotbase/src/main/java/frc/robot/Constants.java
+++ b/robotbase/src/main/java/frc/robot/Constants.java
@@ -226,8 +226,8 @@ public final class Constants {
   /** Maximum safe speed for the shooter wheels */
   public static final int SHOOTER_MAX_SPEED_RPM = 4000;
 
-  /** Maximum speed for the falcons running the shooter motors */
-  public static final int MAX_FALCON_SPEED = 6000;
+  /** Maximum speed for shooter at rest */
+  public static final int SHOOTER_MAX_RESTING_SPEED = 2000;
 
   /** Speed for shooting in the low goal SET THIS */
   public static final int SHOOTER_LOW_GOAL_SPEED_RPM = 1000;


### PR DESCRIPTION
The shooter subsystem runs at 2000rpm on startup, and the shoot command runs at 4000rpm on initialize, and runs down to 2000rpm on end.