### PR TITLE
Add/center on ball autocommand

### DIFF
--- a/robotbase/src/main/java/com/systemmeltdown/robot/commands/AutoCenterOnBall.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/commands/AutoCenterOnBall.java
@@ -1,8 +1,6 @@
 package com.systemmeltdown.robot.commands;
 
 import com.systemmeltdown.robot.subsystems.StorageSubsystem;
-import com.systemmeltdown.robot.subsystems.StorageSubsystem.Configuration;
-
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.Constants;

--- a/robotbase/src/main/java/com/systemmeltdown/robot/commands/AutoCenterOnBall.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/commands/AutoCenterOnBall.java
@@ -1,0 +1,32 @@
+package com.systemmeltdown.robot.commands;
+
+import com.systemmeltdown.robot.subsystems.StorageSubsystem;
+import com.systemmeltdown.robot.subsystems.StorageSubsystem.Configuration;
+
+import edu.wpi.first.wpilibj.DigitalInput;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants;
+
+class AutoCenterOnBall extends CommandBase {
+    // I don't know what port the sensor is being plugged into, so I have to do this for now.
+    private DigitalInput m_infraredSensor;
+    
+    private StorageSubsystem m_storageSub;
+
+    public AutoCenterOnBall(StorageSubsystem storageSub, int port) {
+        m_infraredSensor = new DigitalInput(port);
+
+        m_storageSub = storageSub;
+    }
+
+    @Override
+    public void initialize() {
+        m_storageSub.setRotationSpeed(Constants.STORAGE_CAROUSEL_ROTATION_SPEED);
+        boolean ballDetected = m_infraredSensor.get();
+
+        while (!ballDetected) {/*Nothing*/}
+
+        m_storageSub.setRotationSpeed(0.0);
+        m_storageSub.resetEncoderPos();
+    }
+}

--- a/robotbase/src/main/java/com/systemmeltdown/robot/commands/AutoCenterOnBall.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/commands/AutoCenterOnBall.java
@@ -38,4 +38,9 @@ class AutoCenterOnBall extends CommandBase {
         m_storageSub.setRotationSpeed(0.0);
         m_storageSub.resetEncoderPos();
     }
+
+    @Override
+    public boolean isFinished() {
+        return true;
+    }
 }

--- a/robotbase/src/main/java/com/systemmeltdown/robot/commands/AutoCenterOnBall.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/commands/AutoCenterOnBall.java
@@ -5,12 +5,23 @@ import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 import frc.robot.Constants;
 
+/**
+ * A command that should automatically run at the beginning of every match.
+ * This command will rotate the carousel until a ball is detected by the 
+ * infrared sensor in the storage. When a ball is detected, the Encoder in
+ * the storage will be reset so that it centers on the point the carousel
+ * was stopped at.
+ */
 class AutoCenterOnBall extends CommandBase {
-    // I don't know what port the sensor is being plugged into, so I have to do this for now.
     private DigitalInput m_infraredSensor;
-    
     private StorageSubsystem m_storageSub;
 
+    /**
+     * @param storageSub The {@link storageSub}. Needed so this command can rotate
+     *                   the carousel.
+     * 
+     * @param port       The port the infrared sensor in the storage is plugged into.
+     */
     public AutoCenterOnBall(StorageSubsystem storageSub, int port) {
         m_infraredSensor = new DigitalInput(port);
 

--- a/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/StorageSubsystem.java
+++ b/robotbase/src/main/java/com/systemmeltdown/robot/subsystems/StorageSubsystem.java
@@ -110,6 +110,13 @@ public class StorageSubsystem extends ClosedLoopSubsystem {
         return m_throughBoreEncoder.get();
     }
 
+    /**
+     * Resets the Encoder distance to zero. Mostly used for the AutoCenterOnBall Command.
+     */
+    public void resetEncoderPos() {
+        m_throughBoreEncoder.reset();
+    }
+
     /** Set the rotation motor percent output */
     public void setRotationSpeed(double speed) {
         if (!rotatePositive) {


### PR DESCRIPTION
Add an autocommand that (at the beginning of a match) rotates the carousel until the infrared sensor in the storage sub senses a ball.